### PR TITLE
Fixing sphinx url in the readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@
 
   <p align="center">
     This is the repo for the <a href="https://atom-robotics-lab.github.io">atom-robotics-lab</a> website, a documentation site for the our Projects. The wiki's purpose is to “Provide documentation for our project" - visit our <a href="https://atom-robotics-lab.github.io/wiki">wiki</a>.
-    If you’re interested in helping to improve our <a href="https://atom-robotics-lab.github.io/wiki">wiki</a>, find out how to <a href="https://github.com/atom-robotics-lab/wiki/contributing.md">contribute<a>. 
+    If you’re interested in helping to improve our <a href="https://atom-robotics-lab.github.io/wiki">wiki</a>, find out how to <a href="https://github.com/RJ025/wiki/blob/main/contributing.md">contribute<a>. 
     <br />
     <a href="https://atom-robotics-lab.github.io/wiki"><strong>Our wiki »</strong></a>
     <br />
@@ -80,7 +80,7 @@
 ## About The Project
 
 This is the repo for the <a href="https://atom-robotics-lab.github.io">atom-robotics-lab</a> website, a documentation site for the our Projects. The wiki's purpose is to “Provide documentation for our project" - visit our <a href="https://atom-robotics-lab.github.io/wiki">wiki</a>.
-If you’re interested in helping to improve our <a href="https://atom-robotics-lab.github.io/wiki">wiki</a>, find out how to <a href="https://github.com/atom-robotics-lab/wiki/contributing.md">contribute<a>.  
+If you’re interested in helping to improve our <a href="https://atom-robotics-lab.github.io/wiki">wiki</a>, find out how to <a href="https://github.com/RJ025/wiki/blob/main/contributing.md">contribute<a>.  
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -88,7 +88,7 @@ If you’re interested in helping to improve our <a href="https://atom-robotics-
 
 ### Built With
 
-* [![Sphinx](https://img.shields.io/badge/Made%20with-Sphinx-1f425f.svg)](https://www.sphinx-docs.org)
+* [![Sphinx](https://img.shields.io/badge/Made%20with-Sphinx-1f425f.svg)](https://www.sphinx-doc.org/)
 * [![Python](https://img.shields.io/badge/Python-3776AB?style=for-the-badge&logo=python&logoColor=white)](https://www.python.org/)
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
@@ -193,6 +193,7 @@ Wiki Link: [https://github.com/atom-robotics-lab/wiki](https://github.com/atom-r
 * [Sphinx Offical Documentation](https://www.sphinx-doc.org/en/master/examples.html)
 * [Pythonhosted Sphinx Documentation](https://pythonhosted.org/an_example_pypi_project/sphinx.html)
 * [Readthedocs Sphinx Documentation](https://docs.readthedocs.io/en/stable/intro/getting-started-with-sphinx.html)
+* [wiki](https://atom-robotics-lab.github.io/wiki/)
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 


### PR DESCRIPTION
solved issue #37 
- added atom's wiki link in acknowledgement section 
-  changed sphinx's link in "built with" section
-  changed contributing.md's link in "project description" and "about the project"